### PR TITLE
added ability to preserve pre-defined values by specifying preserve: true in any rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ matches the file, the corresponding `metadata` are set on the file entry, For a
 given file, all patterns are tested, so if several rules are matching, the later
 can override the previously applied rules.
 
+Adding the `preserve: true` to any rule will prevent overriding pre-defined values.
+
 ## CLI usage
 
 ```json

--- a/index.js
+++ b/index.js
@@ -7,9 +7,12 @@ var Matcher = require('minimatch').Minimatch;
  * @param metadata {Object}
  * @private
  */
-function setMetadata(file, metadata) {
-    Object.keys(metadata).forEach(function (key) {
-        file[key] = metadata[key];
+function setMetadata(file, rule) {
+    Object.keys(rule.metadata).forEach(function (key) {
+        if (rule.preserve && key in file) {
+            return;
+        }
+        file[key] = rule.metadata[key];
     });
 }
 
@@ -29,7 +32,8 @@ module.exports = function (rules) {
     rules.forEach(function (rule) {
         matchers.push({
             matcher: new Matcher(rule.pattern),
-            metadata: rule.metadata
+            metadata: rule.metadata,
+            preserve: rule.preserve,
         });
     });
 
@@ -39,7 +43,7 @@ module.exports = function (rules) {
 
             matchers.forEach(function (rule) {
                 if ( rule.matcher.match(file) ) {
-                    setMetadata(fileObject, rule.metadata);
+                    setMetadata(fileObject, rule);
                 }
             });
         });

--- a/tests/file-metadata.js
+++ b/tests/file-metadata.js
@@ -61,4 +61,28 @@ describe('File metadata plugin', function () {
             assert.equal(time, files.file2.time);
         });
     });
+
+    it('should preserve pre-defined metadata when opts.preserve == true', function () {
+        var town = 'NYC',
+            time = '19:45',
+            files = {
+                "file1": {
+                     town: town,
+                     time: time,
+                },
+            },
+            func = fm([{
+                preserve: true,
+                metadata: {
+                    town: 'St Paul de Varax',
+                    time: '7:45',
+                },
+                pattern: '*',
+            }]);
+
+        func(files, metalsmith, function () {
+            assert.equal(town, files.file1.town);
+            assert.equal(time, files.file1.time);
+        });
+    });
 });


### PR DESCRIPTION
Needed for something like defining specific templates only where needed, but defaulting to filemetadata rule otherwise.
